### PR TITLE
Add main import.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+var fs = require('fs');
+var path = require('path');
+var categories = fs.readdirSync(path.join(__dirname, "category"));
+
+var exportCategories = {};
+for (var i = 0; i < categories.length; i++) {
+  var file = categories[i];
+  if (file.endsWith('.js')) {
+    var cat = file.slice(0, -3);
+    exportCategories[cat] = require('./category/' + cat);
+  }
+}
+
+module.exports = {
+  category: exportCategories
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "git://github.com/eversport/node-unicodetable.git"
   },
+  "main": "index.js",
   "engines": {
     "node": ">= 0.8.x"
   },


### PR DESCRIPTION
This PR is to add a main import, in case you want to import the whole package rather than just a specific part. You will still be able to use both methods.

```js
require('unicode/category/So')
```
is equivalent to
```js
require('unicode').category.So
```